### PR TITLE
Add 'djangocms_icon' to Installation instructions.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,7 @@ For a manual install:
 * run ``pip install djangocms-bootstrap4``
 * add the following entries to your ``INSTALLED_APPS``::
 
+    'djangocms_icon',
     'djangocms_link',
     'djangocms_picture',
     'djangocms_bootstrap4',


### PR DESCRIPTION
The dependency for djangocms-icon exists in setup.py and it is
mentioned in the Configuration section, but 'djangocms_icon'
should also be listed in the installation instruction for
INSTALLED_APPS.