### PR TITLE
Update build matrix to test django 1.8-1.11 and python 2.7/3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,32 @@ sudo: false
 
 env:
   - TOX_ENV=flake8
-  - TOX_ENV=py27-latest
-  - TOX_ENV=py34-latest
-  # Django 1.8
+  # Django 2.0 is not yet supported by django-cms
+  # - TOX_ENV=py36-latest
+  - TOX_ENV=py36-dj18-cms35
+  - TOX_ENV=py36-dj18-cms34
+  - TOX_ENV=py36-dj18-cms33
+  - TOX_ENV=py27-dj18-cms35
   - TOX_ENV=py27-dj18-cms34
   - TOX_ENV=py27-dj18-cms33
-  - TOX_ENV=py34-dj18-cms34
-  - TOX_ENV=py34-dj18-cms33
-  # Django 1.9
+  - TOX_ENV=py36-dj19-cms35
+  - TOX_ENV=py36-dj19-cms34
+  - TOX_ENV=py36-dj19-cms33
+  - TOX_ENV=py27-dj19-cms35
   - TOX_ENV=py27-dj19-cms34
   - TOX_ENV=py27-dj19-cms33
-  - TOX_ENV=py34-dj19-cms34
-  - TOX_ENV=py34-dj19-cms33
+  - TOX_ENV=py36-dj110-cms35
+  - TOX_ENV=py36-dj110-cms34
+  - TOX_ENV=py36-dj110-cms33
+  - TOX_ENV=py27-dj110-cms35
+  - TOX_ENV=py27-dj110-cms34
+  - TOX_ENV=py27-dj110-cms33
+  - TOX_ENV=py36-dj111-cms35
+  - TOX_ENV=py36-dj111-cms34
+  - TOX_ENV=py36-dj111-cms33
+  - TOX_ENV=py27-dj111-cms35
+  - TOX_ENV=py27-dj111-cms34
+  - TOX_ENV=py27-dj111-cms33
 
 install:
   - pip install tox coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: python
+python:
+  - "2.7"
+  - "3.6"
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,30 +11,23 @@ env:
   # - TOX_ENV=py36-latest
   - TOX_ENV=py36-dj18-cms35
   - TOX_ENV=py36-dj18-cms34
-  - TOX_ENV=py36-dj18-cms33
   - TOX_ENV=py27-dj18-cms35
   - TOX_ENV=py27-dj18-cms34
-  - TOX_ENV=py27-dj18-cms33
   - TOX_ENV=py36-dj19-cms35
   - TOX_ENV=py36-dj19-cms34
-  - TOX_ENV=py36-dj19-cms33
   - TOX_ENV=py27-dj19-cms35
   - TOX_ENV=py27-dj19-cms34
-  - TOX_ENV=py27-dj19-cms33
   - TOX_ENV=py36-dj110-cms35
   - TOX_ENV=py36-dj110-cms34
-  - TOX_ENV=py36-dj110-cms33
   - TOX_ENV=py27-dj110-cms35
   - TOX_ENV=py27-dj110-cms34
-  - TOX_ENV=py27-dj110-cms33
   - TOX_ENV=py36-dj111-cms35
   - TOX_ENV=py36-dj111-cms34
-  - TOX_ENV=py36-dj111-cms33
   - TOX_ENV=py27-dj111-cms35
   - TOX_ENV=py27-dj111-cms34
-  - TOX_ENV=py27-dj111-cms33
 
 install:
+  - pip install --upgrade pip setuptools
   - pip install tox coverage
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,32 @@
 language: python
 python:
-  - "2.7"
   - "3.6"
 
 sudo: false
 
 env:
-  - TOX_ENV=flake8
+  - TOX_ENV=lint
   # Django 2.0 is not yet supported by django-cms
   # - TOX_ENV=py36-latest
-  - TOX_ENV=py36-dj18-cms35
-  - TOX_ENV=py36-dj18-cms34
-  - TOX_ENV=py27-dj18-cms35
-  - TOX_ENV=py27-dj18-cms34
-  - TOX_ENV=py36-dj19-cms35
-  - TOX_ENV=py36-dj19-cms34
-  - TOX_ENV=py27-dj19-cms35
-  - TOX_ENV=py27-dj19-cms34
-  - TOX_ENV=py36-dj110-cms35
-  - TOX_ENV=py36-dj110-cms34
-  - TOX_ENV=py27-dj110-cms35
-  - TOX_ENV=py27-dj110-cms34
-  - TOX_ENV=py36-dj111-cms35
-  - TOX_ENV=py36-dj111-cms34
-  - TOX_ENV=py27-dj111-cms35
-  - TOX_ENV=py27-dj111-cms34
+  - TOX_ENV=test-py36-dj18-cms35
+  - TOX_ENV=test-py36-dj18-cms34
+  - TOX_ENV=test-py27-dj18-cms35
+  - TOX_ENV=test-py27-dj18-cms34
+  - TOX_ENV=test-py36-dj19-cms35
+  - TOX_ENV=test-py36-dj19-cms34
+  - TOX_ENV=test-py27-dj19-cms35
+  - TOX_ENV=test-py27-dj19-cms34
+  - TOX_ENV=test-py36-dj110-cms35
+  - TOX_ENV=test-py36-dj110-cms34
+  - TOX_ENV=test-py27-dj110-cms35
+  - TOX_ENV=test-py27-dj110-cms34
+  - TOX_ENV=test-py36-dj111-cms35
+  - TOX_ENV=test-py36-dj111-cms34
+  - TOX_ENV=test-py27-dj111-cms35
+  - TOX_ENV=test-py27-dj111-cms34
 
 install:
-  - pip install --upgrade pip setuptools
-  - pip install tox coverage
+  - pip install --upgrade pip setuptools tox coverage
 
 script:
   - tox -e $TOX_ENV

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,11 @@
 [tox]
 envlist =
     flake8
-    py{34,27}-latest
-    py{34,27}-dj18-cms{34,33}
-    py{34,27}-dj19-cms{34,33}
+    py{36}-latest
+    py{36,27}-dj18-cms{35,34,33}
+    py{36,27}-dj19-cms{35,34,33}
+    py{36,27}-dj110-cms{35,34}
+    py{36,27}-dj111-cms{35,34}
 
 skip_missing_interpreters=True
 
@@ -13,9 +15,12 @@ deps =
     -r{toxinidir}/tests/requirements.txt
     dj18: Django>=1.8,<1.9
     dj19: Django>=1.9,<1.10
+    dj110: Django>=1.10,<1.11
+    dj111: Django>=1.11,<2
     latest: django-cms
     cms33: django-cms>=3.3,<3.4
     cms34: django-cms>=3.4,<3.5
+    cms34: django-cms>=3.5,<3.6
 commands =
     {envpython} --version
     {env:COMMAND:coverage} erase

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 envlist =
     flake8
     py{36}-latest
-    py{36,27}-dj18-cms{35,34,33}
-    py{36,27}-dj19-cms{35,34,33}
+    py{36,27}-dj18-cms{35,34}
+    py{36,27}-dj19-cms{35,34}
     py{36,27}-dj110-cms{35,34}
     py{36,27}-dj111-cms{35,34}
 
@@ -14,11 +14,13 @@ skip_missing_interpreters=True
 deps =
     -r{toxinidir}/tests/requirements.txt
     dj18: Django>=1.8,<1.9
+    dj18: django-polymorphic<2
     dj19: Django>=1.9,<1.10
+    dj19: django-polymorphic<2
     dj110: Django>=1.10,<1.11
+    dj110: django-polymorphic<2
     dj111: Django>=1.11,<2
     latest: django-cms
-    cms33: django-cms>=3.3,<3.4
     cms34: django-cms>=3.4,<3.5
     cms34: django-cms>=3.5,<3.6
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,18 @@
 [tox]
 envlist =
-    flake8
-    py{36}-latest
-    py{36,27}-dj18-cms{35,34}
-    py{36,27}-dj19-cms{35,34}
-    py{36,27}-dj110-cms{35,34}
-    py{36,27}-dj111-cms{35,34}
+    lint
+    test-py{36}-latest
+    test-py{36,27}-dj18-cms{35,34}
+    test-py{36,27}-dj19-cms{35,34}
+    test-py{36,27}-dj110-cms{35,34}
+    test-py{36,27}-dj111-cms{35,34}
 
 skip_missing_interpreters=True
 
 
 [testenv]
 deps =
-    -r{toxinidir}/tests/requirements.txt
+    test: -r{toxinidir}/tests/requirements.txt
     dj18: Django>=1.8,<1.9
     dj18: django-polymorphic<2
     dj19: Django>=1.9,<1.10
@@ -22,12 +22,14 @@ deps =
     dj111: Django>=1.11,<2
     latest: django-cms
     cms34: django-cms>=3.4,<3.5
-    cms34: django-cms>=3.5,<3.6
+    cms35: django-cms>=3.5,<3.6
+    lint: flake8
 commands =
     {envpython} --version
-    {env:COMMAND:coverage} erase
-    {env:COMMAND:coverage} run setup.py test
-    {env:COMMAND:coverage} report
+    test: {env:COMMAND:coverage} erase
+    test: {env:COMMAND:coverage} run setup.py test
+    test: {env:COMMAND:coverage} report
+    lint: flake8 djangocms_bootstrap4
 
 [flake8]
 max-line-length = 120


### PR DESCRIPTION
Tests now fail because linting is actually going over the files. Linting is fixed in https://github.com/divio/djangocms-bootstrap4/pull/40