### PR TITLE
Add <code> element inside <pre> in code block

### DIFF
--- a/djangocms_bootstrap4/contrib/bootstrap4_content/templates/djangocms_bootstrap4/code.html
+++ b/djangocms_bootstrap4/contrib/bootstrap4_content/templates/djangocms_bootstrap4/code.html
@@ -1,1 +1,1 @@
-{% load i18n cms_tags %}<{{ instance.tag_type }} {{ instance.attributes_str }}>{{ instance.code_content }}</{{ instance.tag_type }}>
+{% load i18n cms_tags %}<{{ instance.tag_type }} {{ instance.attributes_str }}>{% if instance.tag_type == 'pre' %}<code>{% endif %}{{ instance.code_content }}{% if instance.tag_type == 'pre' %}</code>{% endif %}</{{ instance.tag_type }}>


### PR DESCRIPTION
Adds a nested `<code>` element for the block/pre code plugin for more semantic
HTML.