### PR TITLE
Fix Plural-Forms of i18n for english language

### DIFF
--- a/djangocms_bootstrap4/locale/en/LC_MESSAGES/django.po
+++ b/djangocms_bootstrap4/locale/en/LC_MESSAGES/django.po
@@ -16,7 +16,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 #: constants.py:10
 #: contrib/bootstrap4_grid/templates/djangocms_bootstrap4/admin/grid_column.html:13


### PR DESCRIPTION
It still receives warnings:

```
$> msgfmt -c .../djangocms-bootstrap4/djangocms_bootstrap4/locale/en/LC_MESSAGES

msgfmt: ./django.po: warning: PO file header fuzzy                                             
                     warning: older versions of msgfmt will give an error on this                          
./django.po:8: warning: header field 'Project-Id-Version' still has the initial default value
./django.po:8: warning: header field 'PO-Revision-Date' still has the initial default value    
./django.po:8: warning: header field 'Last-Translator' still has the initial default value
./django.po:8: warning: header field 'Language-Team' still has the initial default value                                      
./django.po:8: warning: header field 'Language' still has the initial default value                                        
```

But the critical error (see #58) should be fixed with this.