### PR TITLE
Fixed a regression with collapse plugins

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+1.1.4 (unreleased)
+==================
+
+* Fixed a regression with collapse plugins
+
 1.1.3 (2018-10-19)
 
 * Adapt Bootstrap4Picture to reflect djangocms_picture.AbstractPicture changes regarding Responsive Images (#65)

--- a/djangocms_bootstrap4/contrib/bootstrap4_collapse/templates/djangocms_bootstrap4/collapse-container.html
+++ b/djangocms_bootstrap4/contrib/bootstrap4_collapse/templates/djangocms_bootstrap4/collapse-container.html
@@ -1,10 +1,10 @@
 {% load cms_tags %}
 
-<{{ instance.tag_type }} {{ instance.attributes_str }}
-    id="{{ instance.identifier }}"
+<{{ instance.tag_type }} {{ instance.attributes_str }}
+    id="container-{{ instance.identifier }}"
     role="tabpanel"
     data-parent="#parent-{{ parent.pk }}"
-    aria-labelledby="{{ instance.identifier }}"
+    aria-labelledby="trigger-{{ instance.identifier }}"
 >
     {% for plugin in instance.child_plugin_instances %}
         {% with forloop as parentloop %}{% render_plugin plugin %}{% endwith %}

--- a/djangocms_bootstrap4/contrib/bootstrap4_collapse/templates/djangocms_bootstrap4/collapse-trigger.html
+++ b/djangocms_bootstrap4/contrib/bootstrap4_collapse/templates/djangocms_bootstrap4/collapse-trigger.html
@@ -1,11 +1,11 @@
 {% load cms_tags %}
 
-<{{ instance.tag_type }} {{ instance.attributes_str }}
-    id="{{ instance.identifier }}"
+<{{ instance.tag_type }} {{ instance.attributes_str }}
+    id="trigger-{{ instance.identifier }}"
     role="tab"
     data-toggle="collapse"
-    data-target="#{{ instance.identifier }}"
-    aria-controls="{{ instance.identifier }}"
+    data-target="#container-{{ instance.identifier }}"
+    aria-controls="container-{{ instance.identifier }}"
     aria-expanded="false"
 >
     {% for plugin in instance.child_plugin_instances %}


### PR DESCRIPTION
This commit made the ids of trigger and container same
https://github.com/divio/djangocms-bootstrap4/pull/20/commits/dee89d8627676b18c4fb731e34cb2797266aab9f

which confused js as to what to show or hide

Fixes #36