### PR TITLE
Fixes djangocms-picture compatibility issues and removed Django <=1.10 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,25 +5,18 @@ python:
 sudo: false
 
 env:
-  - TOX_ENV=lint
-  # Django 2.0 is not yet supported by django-cms
-  # - TOX_ENV=py36-latest
-  - TOX_ENV=test-py36-dj18-cms35
-  - TOX_ENV=test-py36-dj18-cms34
-  - TOX_ENV=test-py27-dj18-cms35
-  - TOX_ENV=test-py27-dj18-cms34
-  - TOX_ENV=test-py36-dj19-cms35
-  - TOX_ENV=test-py36-dj19-cms34
-  - TOX_ENV=test-py27-dj19-cms35
-  - TOX_ENV=test-py27-dj19-cms34
-  - TOX_ENV=test-py36-dj110-cms35
-  - TOX_ENV=test-py36-dj110-cms34
-  - TOX_ENV=test-py27-dj110-cms35
-  - TOX_ENV=test-py27-dj110-cms34
-  - TOX_ENV=test-py36-dj111-cms35
-  - TOX_ENV=test-py36-dj111-cms34
-  - TOX_ENV=test-py27-dj111-cms35
-  - TOX_ENV=test-py27-dj111-cms34
+  - TOX_ENV=flake8
+  # Django 1.11
+  - TOX_ENV=py27-dj111-cms34
+  - TOX_ENV=py27-dj111-cms35
+  - TOX_ENV=py35-dj111-cms34
+  - TOX_ENV=py35-dj111-cms35
+  # Django 2.0
+  - TOX_ENV=py35-dj20-cms35
+  - TOX_ENV=py35-dj20-cms40
+  # Django 2.1
+  - TOX_ENV=py35-dj21-cms35
+  - TOX_ENV=py35-dj21-cms40
 
 install:
   - pip install --upgrade pip setuptools tox coverage

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,12 +2,18 @@
 Changelog
 =========
 
+1.1.5 (unreleased)
+==================
+
+* Fixed a regression with spacing utilities rendering incorrectly
+
 1.1.4 (2018-11-05)
 ==================
 
 * Fixed a regression with collapse plugins
 
 1.1.3 (2018-10-19)
+==================
 
 * Adapt Bootstrap4Picture to reflect djangocms_picture.AbstractPicture changes regarding Responsive Images (#65)
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Changelog
 ==================
 
 * Fixed a regression with spacing utilities rendering incorrectly
-* Fixed a regression with migrations failing
+* Fixed a regression where migrations are failing
 
 
 1.1.4 (2018-11-05)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,15 +8,18 @@ Changelog
 * Fixed a regression with spacing utilities rendering incorrectly
 * Fixed a regression with migrations failing
 
+
 1.1.4 (2018-11-05)
 ==================
 
 * Fixed a regression with collapse plugins
 
+
 1.1.3 (2018-10-19)
 ==================
 
 * Adapt Bootstrap4Picture to reflect djangocms_picture.AbstractPicture changes regarding Responsive Images (#65)
+
 
 1.1.2 (2018-10-05)
 ==================
@@ -26,11 +29,13 @@ Changelog
 * Add <code> element inside <pre> in code block
 * Fix spacing class for XS devices
 
+
 1.1.1 (2018-07-17)
 ==================
 
 * Fixed a bug where offset values wouldn't be rendered in bootstrap grid
 * Fixed a bug where offset and order fields wouldn't allow for zeroes
+
 
 1.1.0 (2018-07-11)
 ==================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,9 +2,10 @@
 Changelog
 =========
 
-1.1.5 (unreleased)
+1.2.0 (unreleased)
 ==================
 
+* Removed support for Django 1.8, 1.9, 1.10
 * Fixed a regression with spacing utilities rendering incorrectly
 * Fixed a regression where migrations are failing
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Changelog
 ==================
 
 * Fixed a regression with spacing utilities rendering incorrectly
+* Fixed a regression with migrations failing
 
 1.1.4 (2018-11-05)
 ==================

--- a/README.rst
+++ b/README.rst
@@ -33,13 +33,13 @@ Documentation
 See ``REQUIREMENTS`` in the `setup.py <https://github.com/divio/djangocms-bootstrap4/blob/master/setup.py>`_
 file for additional dependencies:
 
-* Python 2.7, 3.3 or higher
-* Django 1.8 or higher
+* Python 2.7, 3.4 or higher
+* Django 1.11 or higher
 * Django Filer 1.2.4 or higher
 * Django Text CKEditor 3.1.0 or higher
 * Django CMS Icon 1.0.0 or higher
 * Django CMS Link 2.1.0 or higher
-* Django CMS Picture 2.0.6 or higher
+* Django CMS Picture 2.1.1 or higher
 
 Make sure `django Filer <http://django-filer.readthedocs.io/en/latest/installation.html>`_
 and `django CMS Text CKEditor <https://github.com/divio/djangocms-text-ckeditor>`_

--- a/djangocms_bootstrap4/contrib/bootstrap4_picture/migrations/0001_initial.py
+++ b/djangocms_bootstrap4/contrib/bootstrap4_picture/migrations/0001_initial.py
@@ -39,7 +39,7 @@ class Migration(migrations.Migration):
                 ('link_url', models.URLField(blank=True, help_text='Wraps the image in a link to an external URL.', max_length=2040, verbose_name='External URL')),
                 ('link_target', models.CharField(blank=True, choices=LINK_TARGET, max_length=255, verbose_name='Link target')),
                 ('link_attributes', djangocms_attributes_field.fields.AttributesField(blank=True, default=dict, verbose_name='Link attributes')),
-                ('use_automatic_scaling', models.BooleanField(default=True, help_text='Uses the placeholder dimenstions to automatically calculate the size.', verbose_name='Automatic scaling')),
+                ('use_automatic_scaling', models.BooleanField(default=True, help_text='Uses the placeholder dimensions to automatically calculate the size.', verbose_name='Automatic scaling')),
                 ('use_no_cropping', models.BooleanField(default=False, help_text='Outputs the raw image without cropping.', verbose_name='Use original image')),
                 ('use_crop', models.BooleanField(default=False, help_text='Crops the image according to the thumbnail settings provided in the template.', verbose_name='Crop image')),
                 ('use_upscale', models.BooleanField(default=False, help_text='Upscales the image to the size of the thumbnail settings in the template.', verbose_name='Upscale image')),

--- a/djangocms_bootstrap4/contrib/bootstrap4_picture/migrations/0002_bootstrap4picture_use_responsive_image.py
+++ b/djangocms_bootstrap4/contrib/bootstrap4_picture/migrations/0002_bootstrap4picture_use_responsive_image.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 from django.db import migrations, models
+from djangocms_picture.models import RESPONSIVE_IMAGE_CHOICES
 
 
 class Migration(migrations.Migration):
@@ -15,6 +16,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='Bootstrap4Picture',
             name='use_responsive_image',
-            field=models.CharField(choices=[('inherit', 'Let settings.DJANGOCMS_PICTURE_RESPONSIVE_IMAGES decide'), ('yes', 'Yes'), ('no', 'No')], default='inherit', help_text='Uses responsive image technique to choose better image to display based upon screen viewport. This configuration only applies to uploaded images (external pictures will not be affected). ', max_length=7, verbose_name='Use responsive image'),
+            field=models.CharField(choices=RESPONSIVE_IMAGE_CHOICES, default='inherit', help_text='Uses responsive image technique to choose better image to display based upon screen viewport. This configuration only applies to uploaded images (external pictures will not be affected). ', max_length=7, verbose_name='Use responsive image'),
         ),
     ]

--- a/djangocms_bootstrap4/contrib/bootstrap4_picture/migrations/0002_bootstrap4picture_use_responsive_image.py
+++ b/djangocms_bootstrap4/contrib/bootstrap4_picture/migrations/0002_bootstrap4picture_use_responsive_image.py
@@ -10,6 +10,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('bootstrap4_picture', '0001_initial'),
+        ('djangocms_picture', '0008_picture_use_responsive_image'),
     ]
 
     operations = [

--- a/djangocms_bootstrap4/contrib/bootstrap4_picture/models.py
+++ b/djangocms_bootstrap4/contrib/bootstrap4_picture/models.py
@@ -30,5 +30,8 @@ class Bootstrap4Picture(AbstractPicture):
         help_text=_('Adds the .img-thumbnail class.'),
     )
 
+    class Meta:
+        abstract = False
+
     def __str__(self):
         return str(self.pk)

--- a/djangocms_bootstrap4/contrib/bootstrap4_utilities/models.py
+++ b/djangocms_bootstrap4/contrib/bootstrap4_utilities/models.py
@@ -57,7 +57,7 @@ class Bootstrap4Spacing(CMSPlugin):
     def get_base_css_class(self):
         # Source: https://getbootstrap.com/docs/4.0/utilities/spacing/#notation
         # [...] format {property}{sides}-{size} for xs and {property}{sides}-{breakpoint}-{size} for sm, md, lg, and xl.
-        if self.space_device == 'xs':
+        if not self.space_device or self.space_device == 'xs':
             template = '{property}{sides}-{size}'
         else:
             template = '{property}{sides}-{breakpoint}-{size}'

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ REQUIREMENTS = [
     'djangocms-attributes-field>=0.1.1',
     'djangocms-icon>=1.0.0',
     'djangocms-link>=2.1.0',
-    'djangocms-picture>=2.0.7',
+    'djangocms-picture>=2.1.1',
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
     'Topic :: Internet :: WWW/HTTP',
     'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     'Topic :: Software Development :: Libraries :: Application Frameworks',

--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,10 @@ from djangocms_bootstrap4 import __version__
 
 
 REQUIREMENTS = [
-    'django-cms>=3.4.0',
+    'django-cms>=3.4.5',
     'django-filer>=1.2.4',
     'djangocms-text-ckeditor>=3.1.0',
-    'djangocms-attributes-field>=0.1.1',
+    'djangocms-attributes-field>=0.4.0',
     'djangocms-icon>=1.0.0',
     'djangocms-link>=2.1.0',
     'djangocms-picture>=2.1.1',

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,9 +1,9 @@
 # requirements from setup.py
-djangocms-attributes-field>=0.1.1
+djangocms-attributes-field>=0.4.0
 djangocms-text-ckeditor>=3.1.0
 djangocms-link>=2.1.0
 djangocms-picture>=2.1.1
-djangocms-icon>=0.2.0
+djangocms-icon>=1.0.0
 # other requirements
 djangocms-helper>=0.9.2,<0.10
 tox

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,7 +2,7 @@
 djangocms-attributes-field>=0.1.1
 djangocms-text-ckeditor>=3.1.0
 djangocms-link>=2.1.0
-djangocms-picture>=2.0.6
+djangocms-picture>=2.1.1
 djangocms-icon>=0.2.0
 # other requirements
 djangocms-helper>=0.9.2,<0.10

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist =
-    lint
     flake8
     py{27,34,35,36}-dj111-cms{34,35}
     py{34,35,36}-dj20-cms{35,36,40}

--- a/tox.ini
+++ b/tox.ini
@@ -1,35 +1,27 @@
 [tox]
 envlist =
     lint
-    test-py{36}-latest
-    test-py{36,27}-dj18-cms{35,34}
-    test-py{36,27}-dj19-cms{35,34}
-    test-py{36,27}-dj110-cms{35,34}
-    test-py{36,27}-dj111-cms{35,34}
+    flake8
+    py{27,34,35,36}-dj111-cms{34,35}
+    py{34,35,36}-dj20-cms{35,36,40}
+    py{35,36}-dj21-cms{35,36,40}
 
 skip_missing_interpreters=True
 
-
 [testenv]
 deps =
-    test: -r{toxinidir}/tests/requirements.txt
-    dj18: Django>=1.8,<1.9
-    dj18: django-polymorphic<2
-    dj19: Django>=1.9,<1.10
-    dj19: django-polymorphic<2
-    dj110: Django>=1.10,<1.11
-    dj110: django-polymorphic<2
-    dj111: Django>=1.11,<2
-    latest: django-cms
+    -r{toxinidir}/tests/requirements.txt
+    dj111: Django>=1.11,<2.0
+    dj20: Django>=2.0,<2.1
+    dj21: Django>=2.1,<2.2
     cms34: django-cms>=3.4,<3.5
     cms35: django-cms>=3.5,<3.6
-    lint: flake8
+    cms40: https://github.com/divio/django-cms/archive/release/4.0.x.zip
 commands =
     {envpython} --version
-    test: {env:COMMAND:coverage} erase
-    test: {env:COMMAND:coverage} run setup.py test
-    test: {env:COMMAND:coverage} report
-    lint: flake8 djangocms_bootstrap4
+    {env:COMMAND:coverage} erase
+    {env:COMMAND:coverage} run setup.py test
+    {env:COMMAND:coverage} report
 
 [flake8]
 max-line-length = 120


### PR DESCRIPTION
* Removed support for Django 1.8, 1.9, 1.10
* Align migration typo fix with djangocms-picture
* Fix a regression where the bootstrap4_picture plugin creates an IntegrityError `null value in column "use_responsive_image" violates not-null constraint`
* Make sure migrations use proper variable values
* Also fixes #67

I'm not sure if abstract = False is required, but I assume it is best practice.