### PR TITLE
Bumped version to 1.4.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 =========
 
 
-1.4.0 (unreleased)
+1.4.0 (2019-05-23)
 ==================
 
 * This update requires djangocms-icon >= 1.4.0

--- a/djangocms_bootstrap4/__init__.py
+++ b/djangocms_bootstrap4/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '1.3.1'
+__version__ = '1.4.0'


### PR DESCRIPTION
* This update requires djangocms-icon >= 1.4.0
* Added support for Django 2.2 and django CMS 3.7
* Removed support for Django 2.0
* Extended test matrix
* Added isort and adapted imports
* Adapted code base to align with other supported addons
* Added option to add custom classes to carousel (#82)
* Fixes an issue where ``DJANGOCMS_BOOTSTRAP4_CAROUSEL_DEFAULT_SIZE`` is not honoured
* Fixes an issue on Divio Cloud where the addon is not installing djangocms-icon
