### PR TITLE
Bumped version to 1.5.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 =========
 
 
-1.5.0 (unreleased)
+1.5.0 (2019-07-09)
 ==================
 
 * This update requires djangocms-link>=2.5.0

--- a/djangocms_bootstrap4/__init__.py
+++ b/djangocms_bootstrap4/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '1.4.0'
+__version__ = '1.5.0'


### PR DESCRIPTION
* This update requires djangocms-link>=2.5.0
* This update requires djangocms-picture>=2.3.0
* Added new migrations for bootstrap link and picture plugins
* Fixes offset class not being rendered when set to 0
* Fixes order class not being rendered when set to 0
