### PR TITLE
make it possible to work with sorl thumbnail

### DIFF
--- a/djangocms_bootstrap4/contrib/bootstrap4_carousel/templates/djangocms_bootstrap4/carousel/default/image.html
+++ b/djangocms_bootstrap4/contrib/bootstrap4_carousel/templates/djangocms_bootstrap4/carousel/default/image.html
@@ -1,4 +1,4 @@
-{% load cms_tags thumbnail %}
+{% load cms_tags easy_thumbnails_tags %}
 
 {% thumbnail instance.carousel_image options.size crop=options.crop upscale=options.upscale subject_location=instance.carousel_image.subject_location as thumbnail %}
 


### PR DESCRIPTION
If we do this, there can be worked with other thumbnail libaries as well in a project that has this addon installed.

See https://github.com/SmileyChris/easy-thumbnails/blob/master/easy_thumbnails/templatetags/easy_thumbnails_tags.py