### PR TITLE
fix: Grid compatibility for django CMS v4 plugin architecture

### DIFF
--- a/djangocms_bootstrap4/contrib/bootstrap4_grid/cms_plugins.py
+++ b/djangocms_bootstrap4/contrib/bootstrap4_grid/cms_plugins.py
@@ -89,15 +89,29 @@ class Bootstrap4GridRowPlugin(CMSPluginBase):
                 extra['{}_col'.format(size)] = data.get(
                     'create_{}_col'.format(size)
                 )
+
+            try:
+                # django CMS <= 3
+                plugin_position = obj.numchild
+            except AttributeError:
+                # django CMS >= 4
+                plugin_position = obj.placeholder.get_next_plugin_position(obj.language, obj)
+
             col = Bootstrap4GridColumn(
                 parent=obj,
                 placeholder=obj.placeholder,
                 language=obj.language,
-                position=obj.numchild,
+                position=plugin_position,
                 plugin_type=Bootstrap4GridColumnPlugin.__name__,
                 **extra
             )
-            obj.add_child(instance=col)
+
+            try:
+                # django CMS <= 3
+                obj.add_child(instance=col)
+            except AttributeError:
+                # django CMS >= 4
+                obj.placeholder.add_plugin(instance=col)
 
     def render(self, context, instance, placeholder):
         gutter = 'no-gutters' if instance.gutters else ''


### PR DESCRIPTION
Fixes the following error thrown when trying to create a plugin using the bootstrap grid:

AttributeError at /admin/cms/placeholder/add-plugin/
'Bootstrap4GridRow' object has no attribute 'numchild'