### PR TITLE
Add collapse container to the list of possible child classes

### DIFF
--- a/djangocms_bootstrap4/contrib/bootstrap4_card/cms_plugins.py
+++ b/djangocms_bootstrap4/contrib/bootstrap4_card/cms_plugins.py
@@ -25,6 +25,7 @@ class Bootstrap4CardPlugin(CMSPluginBase):
         'Bootstrap4LinkPlugin',
         'Bootstrap4ListGroupPlugin',
         'Bootstrap4PicturePlugin',
+        'Bootstrap4CollapseContainerPlugin',
     ]
 
     fieldsets = [


### PR DESCRIPTION
This allows the creation of collapsible card bodies, which allows for a more beautiful collapsible card. See below for an example.

The first card contains the hierarchy "Card -> Collapse Container -> Card inner -> ...", while the second card has the following hierarchy "Card -> Card inner -> Collapse Container -> ...".
 
![image](https://user-images.githubusercontent.com/4395770/109360895-4432d700-7888-11eb-8460-6af09197f848.png)
