### PR TITLE
Quick: Avoid Coupling Bootstrap and Generic Link

### DIFF
--- a/djangocms_bootstrap4/contrib/bootstrap4_link/cms_plugins.py
+++ b/djangocms_bootstrap4/contrib/bootstrap4_link/cms_plugins.py
@@ -35,13 +35,12 @@ class Bootstrap4LinkPlugin(LinkPlugin):
             ('icon_left', 'icon_right'),
         )
 
-    LinkPlugin.fieldsets[0] = (
+    fieldsets = copy.deepcopy(LinkPlugin.fieldsets)
+    fieldsets[0] = (
         None, {
             'fields': fields
         }
     )
-
-    fieldsets = LinkPlugin.fieldsets
 
     def get_render_template(self, context, instance, placeholder):
         return get_plugin_template(


### PR DESCRIPTION
# Goal

Do not couple Bootstrap Link plugin to Generic link plugin.

# Changes

1. In Link plugin, mimic [how Picture plugin creates fieldsets from corresponding generic plugin](https://github.com/django-cms/djangocms-bootstrap4/blob/2.0.0/djangocms_bootstrap4/contrib/bootstrap4_picture/cms_plugins.py#L24-L33).

# Testing

Manual testing:

1. Have a CMS that installs Bootstrap4 Link and Picture plugin.
2. Edit code to support Bootstrap __and__ Generic Link and Picture plugin.
    - Install plugin to re-enable Generic Link plugin:
      https://github.com/TACC/Core-CMS/blob/884194e/taccsite_cms/settings.py#L241-L242
    - Add plugin to re-enable Generic Link plugin:
      https://github.com/TACC/Core-CMS/blob/884194e/taccsite_cms/contrib/bootstrap4_djangocms_link/cms_plugins.py
3. Remove extra code for supporting Link plugins:
    - Remove lines https://github.com/TACC/Core-CMS/blob/884194e/taccsite_cms/contrib/bootstrap4_djangocms_link/cms_plugins.py#L7.
    - Remove lines https://github.com/TACC/Core-CMS/blob/884194e/taccsite_cms/contrib/bootstrap4_djangocms_link/cms_plugins.py#L14-L28.
4. Add and save these plugins:
    - "Generic" > "Link"
    - "Bootstrap4" > "Link"

# Background

Supporting (A) Generic "Link" plugin __and__ Bootstrap "Link / Button" plugin _takes more code_ than (B) Generic "Image" plugin __and__ Bootstrap "Picture / Image" plugin, because Bootstrap Link plugin points to Generic Link plugin fieldsets, instead of cloning them (like Bootstrap Picture plugin).

<details>

1. If a user wants to use Generic "Link" plugin __and__ Bootstrap "Link / Button" plugin, they cannot immediately do so.
    - https://github.com/django-cms/djangocms-link/issues/163
    - https://github.com/django-cms/djangocms-link/issues/167
2. A user can do so, by following instructions like these:
    - https://github.com/django-cms/djangocms-link/issues/163#issuecomment-868818891
    - https://github.com/TACC/Core-CMS/pull/278
3. When a user wants to use Generic "Image" plugin __and__ Bootstrap "Picture / Image" plugin, the solution is simpler:
    - https://github.com/TACC/Core-CMS/blob/884194e/taccsite_cms/contrib/bootstrap4_djangocms_picture/cms_plugins.py#L5-L11
4. The solution for Generic "Link" plugin __and__ Bootstrap "Link / Button" plugin, the solution is not as simple:
    - https://github.com/TACC/Core-CMS/blob/884194e/taccsite_cms/contrib/bootstrap4_djangocms_link/cms_plugins.py#L14-L28

</details>