### PR TITLE
docs(README): fix "Running Tests" instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -176,7 +176,7 @@ You can run tests by executing::
 
     virtualenv env
     source env/bin/activate
-    pip install -r tests/requirements.txt
+    pip install -r tests/requirements/djNN_cmsNN.txt # where NN is an available appropriate version
     python setup.py test
 
 To run the frontend make sure to use **node 10.x**.


### PR DESCRIPTION
## Description

Fix `README.md` "Running Tests" instructions.

## Related resources

Problem found when trying to run test cases for https://github.com/django-cms/djangocms-bootstrap4/pull/145#issuecomment-1146662847.

## Checklist

* [x] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic → N/A
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on [Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request. → [request](https://django-cmsworkspace.slack.com/archives/C01J7H87KFC/p1654538745332319)