### PR TITLE
ci: Fix test requirements

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -38,7 +38,6 @@ jobs:
       uses: actions/setup-python@master
       with:
         python-version: ${{ matrix.python-version }}
-        cache: 'pip'
 
     - name: Generate Report
       run: |

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -2,13 +2,17 @@ name: CodeCov
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   coverage:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ 3.7, 3.8, 3.9, ]  # latest release minus two
+        python-version: [ 3.7, 3.8, 3.9, 3.10]
         requirements-file: [
             dj22_cms37.txt,
             dj22_cms38.txt,
@@ -18,13 +22,15 @@ jobs:
             dj30_cms39.txt,
             dj31_cms38.txt,
             dj31_cms39.txt,
+            dj32_cms39.txt,
+            dj32_cms310.txt,
         ]
         os: [
             ubuntu-20.04,
         ]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: '2'
 
@@ -32,9 +38,12 @@ jobs:
       uses: actions/setup-python@master
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+
     - name: Generate Report
       run: |
         pip install -r tests/requirements/${{ matrix.requirements-file }}
         coverage run setup.py test
+
     - name: Upload Coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ 3.7, 3.8, 3.9, 3.10]
+        python-version: [ 3.7, 3.8, 3.9, "3.10"]
         requirements-file: [
             dj22_cms37.txt,
             dj22_cms38.txt,

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
-          cache: 'pip'
       - name: Install flake8
         run: pip install --upgrade flake8
       - name: Run flake8
@@ -35,7 +34,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
-          cache: 'pip'
+
       - run: python -m pip install isort
       - name: isort
         uses: liskin/gh-problem-matcher-wrap@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,10 @@ name: Lint
 
 on: [push]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   flake8:
     name: flake8
@@ -13,7 +17,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
-      - name: Install flate8
+          cache: 'pip'
+      - name: Install flake8
         run: pip install --upgrade flake8
       - name: Run flake8
         uses: liskin/gh-problem-matcher-wrap@v1
@@ -30,6 +35,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
+          cache: 'pip'
       - run: python -m pip install isort
       - name: isort
         uses: liskin/gh-problem-matcher-wrap@v1

--- a/tests/requirements/dj30_cms39.txt
+++ b/tests/requirements/dj30_cms39.txt
@@ -1,4 +1,4 @@
 -r base.txt
 
 Django>=3.0,<3.1
-django-cms>=3.9,<4.0
+django-cms>=3.9,<3.10

--- a/tests/requirements/dj31_cms39.txt
+++ b/tests/requirements/dj31_cms39.txt
@@ -1,4 +1,4 @@
 -r base.txt
 
 Django>=3.1,<3.2
-django-cms>=3.9,<4.0
+django-cms>=3.9,<3.10

--- a/tests/requirements/dj32_cms310.txt
+++ b/tests/requirements/dj32_cms310.txt
@@ -1,0 +1,4 @@
+-r base.txt
+
+Django>=3.2,<4.0
+django-cms>=3.10,<3.11

--- a/tests/requirements/dj32_cms39.txt
+++ b/tests/requirements/dj32_cms39.txt
@@ -1,4 +1,4 @@
 -r base.txt
 
-Django>=2.2,<3.0
+Django>=3.2,<4.0
 django-cms>=3.9,<3.10

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 HELPER_SETTINGS = {
+    'SECRET_KEY': 'not_secret',
     'INSTALLED_APPS': [
         'easy_thumbnails',
         'filer',


### PR DESCRIPTION
## Description

Some of the test requirements intend to install django-cms 3.9 but actually install 3.10 which isn't compatible with django 2.2 so it's causing test failures.
